### PR TITLE
ci(workflow): 添加部署工作流的权限配置

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
添加 contents、pages 和 id-token 的写入权限以支持 GitHub Pages 部署